### PR TITLE
Added -p flag and file_regex

### DIFF
--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -1,6 +1,6 @@
 {
 	"cmd": ["gnuplot", "-p", "$file"],
 	"working_dir": "${project_path:${folder}}",
-	"selector": "source.gnuplot"
+	"selector": "source.gnuplot",
 	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$"
 }

--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -3,5 +3,4 @@
 	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$",
 	"working_dir": "${project_path:${folder}}",
 	"selector": "source.gnuplot"
-	
 }

--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -1,6 +1,7 @@
 {
 	"cmd": ["gnuplot", "-p", "$file"],
+	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$",
 	"working_dir": "${project_path:${folder}}",
-	"selector": "source.gnuplot",
-	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$"
+	"selector": "source.gnuplot"
+	
 }

--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -1,5 +1,6 @@
 {
-	"cmd": ["gnuplot", "$file"],
+	"cmd": ["gnuplot", "-p", "$file"],
 	"working_dir": "${project_path:${folder}}",
 	"selector": "source.gnuplot"
+	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$"
 }


### PR DESCRIPTION
The `-p` flag is needed so that if the user is using a graphical output terminal such as qt or wxt, the output window will stay open after gnuplot finishes.
The `file_regex` allows a user to jump directly to the location of an error, should one occur when running gnuplot.