### PR TITLE
[Fixed] Windows path

### DIFF
--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -1,6 +1,8 @@
 {
 	"cmd": ["gnuplot", "--persist", "$file"],
-	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$",
-	"working_dir": "${project_path:${folder}}",
-	"selector": "source.gnuplot"
+	"selector": "source.gnuplot",
+	// Default path to gnuplot in Windows; it would be nice, if you add setting "gnuplot_path"
+	"windows": {
+		"cmd": ["C:\\Program Files\\gnuplot\\bin\\gnuplot.exe", "--persist", "$file"]
+	}
 }

--- a/gnuplot.sublime-build
+++ b/gnuplot.sublime-build
@@ -1,6 +1,8 @@
 {
 	"cmd": ["gnuplot", "--persist", "$file"],
 	"selector": "source.gnuplot",
+	"file_regex": "^\"([^\"]+)\", line ([0-9]+): (.+)$",
+	"working_dir": "${project_path:${folder}}",
 	// Default path to gnuplot in Windows; it would be nice, if you add setting "gnuplot_path"
 	"windows": {
 		"cmd": ["C:\\Program Files\\gnuplot\\bin\\gnuplot.exe", "--persist", "$file"]


### PR DESCRIPTION
Build don't work for me in Windows 10 64-bit, I get in console:

    [WinError 2] The system cannot find the file specified

See [**Platform-specific options**](http://docs.sublimetext.info/en/latest/reference/build_systems/configuration.html#platform-specific-options).

Thanks.